### PR TITLE
Update alias parsing and add runbook to create a SKU-less bundle.

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -158,7 +158,9 @@ INFO[0001] POST https://api.moltin.com/v2/customers ==> HTTP/1.1 201 Created
    * epcc update customer email=test@test.com name "James Smith"
    * epcc update customer last_read=entity name "Jacob Smith"
 
-8. The alias `last_read=entity` is a special one, and it refers to the last entity with type `customer` that the EPCC CLI saw, similarly when you get a list of all entities (i.e., epcc get customers), you will see aliases like `last_read=array[0]` which is the first element in the last array it was seen. Other aliases may exist as well, so use the `epcc aliases list <resource_type>` to see them. 
+8. The alias `last_read=entity` is a special one, and it refers to the last entity with type `customer` that the EPCC CLI saw, similarly when you get a list of all entities (i.e., epcc get customers), you will see aliases like `last_read=array[0]` which is the first element in the last array it was seen. Other aliases may exist as well, so use the `epcc aliases list <resource_type>` to see them.
+   - Some resources require other resource IDs at creation to tie related components together (for example, when adding components to bundles).  In these cases, the generated ID might not be immediately available for entry, though aliases for the required components exist.  To solve this, use the pattern `<target_id_key> alias/<resource>/name=<alias_name>/id`.  This syntax tells the system to extract the ID field from the resource identified by the alias.
+   - For example, the `publish-catalog-with-bundles` action under the `pxm-how-to.yml` runbook includes the line `components.dogbed.options[0].id alias/product/name=Fluffy_Bed/id`.  This command says that the `dogbed` component ID (under `options`) should use the ID from the product aliased with the name `Fluffy_Bed`.
 
 9. The output of the epcc cli contains a lot of output, however almost all the output is on [standard error](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)), and the only thing *for crud commands* that is output is the JSON response, this means you can pipe the output to a JSON processing library like so:
 ```shell

--- a/external/json/to_json.go
+++ b/external/json/to_json.go
@@ -87,6 +87,14 @@ func toJsonObject(args []string, noWrapping bool, compliant bool, attributes map
 					log.Warnf("Could not find a resource for %s, this is a bug.", resourceType)
 				}
 			}
+		} else {
+			splitAlias := strings.Split(val, "/")
+
+			if len(splitAlias) == 4 {
+				if splitAlias[0] == "alias" {
+					val = aliases.ResolveAliasValuesOrReturnIdentity(splitAlias[1], []string{}, splitAlias[2], splitAlias[3])
+				}
+			}
 		}
 
 		val = formatValue(val)

--- a/external/json/to_json_test.go
+++ b/external/json/to_json_test.go
@@ -372,6 +372,20 @@ func TestToJsonCompliantFormatSimpleArrayWithTwoValues(t *testing.T) {
 	}
 }
 
+func TestToJsonCompliantAliasForNestedArray(t *testing.T) {
+	// Fixture Setup
+	input := []string{"components.shampoo.options[0].id", "alias/product/name=Clean_Shampoo/id"}
+	expected := `{"data":{"attributes":{"components":{"shampoo":{"options":[{"id":"name=Clean_Shampoo"}]}}}}}`
+
+	// Execute SUT
+	actual, _ := ToJson(input, false, true, map[string]*resources.CrudEntityAttribute{})
+
+	// Verification
+	if actual != expected {
+		t.Fatalf("Testing json conversion of empty value %s did not match expected %s, actually: %s", input, expected, actual)
+	}
+}
+
 func TestToJsonErrorsWhenArrayAndObjectKeysSpecified(t *testing.T) {
 	// Fixture Setup
 	input := []string{"[0]", "val", "key", "val2"}

--- a/external/resources/resources.yaml
+++ b/external/resources/resources.yaml
@@ -1553,8 +1553,6 @@ pcm-products:
       type: STRING
     locales.en-US.description:
       type: STRING
-    components.*.options[n].id:
-      type: RESOURCE_ID:pcm-products
 pcm-product-templates:
   singular-name: "pcm-product-template"
   json-api-type: "template"

--- a/external/resources/resources.yaml
+++ b/external/resources/resources.yaml
@@ -1553,6 +1553,8 @@ pcm-products:
       type: STRING
     locales.en-US.description:
       type: STRING
+    components.*.options[n].id:
+      type: RESOURCE_ID:pcm-products
 pcm-product-templates:
   singular-name: "pcm-product-template"
   json-api-type: "template"

--- a/external/runbooks/pxm-how-to.epcc.yml
+++ b/external/runbooks/pxm-how-to.epcc.yml
@@ -102,6 +102,7 @@ actions:
       - epcc create pcm-node-product name=Pet_Supplies name=Dog_Supplies data[0].type product data[0].id name=SKU-less_Bed_and_Ball_Bundle
       - epcc create pcm-catalog name "Pet Supplies Catalog" description "Pet Supplies Catalog" pricebook_id name=VIP_Pricing hierarchy_ids[0] name=Pet_Supplies
       - epcc create pcm-catalog-releases name=Pet_Supplies_Catalog
+      - sleep 2
       - epcc get pcm-catalog-releases name=Pet_Supplies_Catalog
 
   reset:

--- a/external/runbooks/pxm-how-to.epcc.yml
+++ b/external/runbooks/pxm-how-to.epcc.yml
@@ -84,6 +84,26 @@ actions:
       - |
         epcc get pcm-child-products sku=shirt
 
+  publish-catalog-with-bundles:
+    description:
+      short: "Create a sample pet store catalog with bundle products"
+    commands:
+      - epcc create pcm-hierarchy name "Pet Supplies" description "Pet supplies" slug "Pet-Supplies-PS0"
+      - epcc create pcm-node name=Pet_Supplies name "Dog Supplies" description "Supplies for dogs" slug "Dogs-PS1"
+      - epcc create pcm-product name "Fluffy Bed" sku "fluffy-bed-sku" slug "fluffy-bed" description "Fluffy and comfortable dog bed." status live commodity_type physical
+      - epcc create pcm-node-product name=Pet_Supplies name=Dog_Supplies data[0].type product data[0].id sku=fluffy-bed-sku
+      - epcc create pcm-product name "Squeaky Ball" sku "squeaky-ball-sku" slug "squeaky-ball" description "Grey rubber ball with satisfying sqeak." status live commodity_type physical
+      - epcc create pcm-node-product name=Pet_Supplies name=Dog_Supplies data[0].type product data[0].id sku=squeaky-ball-sku
+      - epcc create pcm-pricebook name "VIP Pricing" description "Special pricing for Very Important Pups."
+      - |
+        epcc create pcm-product-price name=VIP_Pricing currencies.USD.amount 5000 currencies.USD.includes_tax false sku fluffy-bed-sku
+        epcc create pcm-product-price name=VIP_Pricing currencies.USD.amount 500 currencies.USD.includes_tax false sku squeaky-ball-sku
+      - epcc create pcm-product attributes.name "SKU-less Bed and Ball Bundle" attributes.commodity_type "physical" status "live" components.dogbed.max 1 components.dogbed.min 1 components.dogbed.name "Dog Bed" components.dogbed.options[0].id alias/product/name=Fluffy_Bed/id components.dogbed.options[0].type "product" components.dogbed.options[0].quantity 1 components.dogball.max 1 components.dogball.min 1 components.dogball.name "Dog Ball" components.dogball.options[0].id alias/product/name=Squeaky_Ball/id components.dogball.options[0].type "product" components.dogball.options[0].quantity 1
+      - epcc create pcm-node-product name=Pet_Supplies name=Dog_Supplies data[0].type product data[0].id name=SKU-less_Bed_and_Ball_Bundle
+      - epcc create pcm-catalog name "Pet Supplies Catalog" description "Pet Supplies Catalog" pricebook_id name=VIP_Pricing hierarchy_ids[0] name=Pet_Supplies
+      - epcc create pcm-catalog-releases name=Pet_Supplies_Catalog
+      - epcc get pcm-catalog-releases name=Pet_Supplies_Catalog
+
   reset:
     description:
       short: "Delete all catalogs, hierarchy and nodes"
@@ -94,18 +114,25 @@ actions:
       - |
         epcc delete currency code=GBP
         epcc delete pcm-catalog-releases name=Ranges_Catalog name=Ranges_Catalog
+        epcc delete pcm-catalog-releases name=Pet_Supplies_Catalog name=Pet_Supplies_Catalog
         epcc delete pcm-catalog-releases name=Ranges_Catalog_for_Special_Customers name=Ranges_Catalog_for_Special_Customers
         epcc delete pcm-catalog-rule name=Catalog_Rule_for_Civil_Servants    
         epcc delete pcm-product name=BestEver_Gas_Range
         epcc delete pcm-product name=BestEver_Electric_Range
+        epcc delete pcm-product name=SKU-less_Bed_and_Ball_Bundle
         epcc delete pcm-hierarchy name=Major_Appliances
         epcc delete pcm-pricebook name=Preferred_Pricing
         epcc delete pcm-pricebook name=Loyal_Civil_Servants_Pricing
         epcc delete customer name=Leslie_Knope
         epcc delete customer name=Ron_Swanson
+        epcc delete pcm-product name=Fluffy_Bed
+        epcc delete pcm-product name=Squeaky_Ball
+        epcc delete pcm-hierarchy name=Pet_Supplies
+        epcc delete pcm-pricebook name=VIP_Pricing
       - |
         epcc delete pcm-catalog name=Ranges_Catalog_for_Special_Customers
         epcc delete pcm-catalog name=Ranges_Catalog
+        epcc delete pcm-catalog name=Pet_Supplies_Catalog
       - | 
         epcc delete flow name=Book
         epcc delete flow name=Condition


### PR DESCRIPTION
## Description
- Updates alias parsing to support extracting IDs from existing resources for nested component identification
- Adds discussion on this alias parsing to `tutorial.md`
- Adds the `publish-catalog-with-bundles` runbook action to automate and simplify bundle creation
- Updates the `reset` runbook action to remove entities created in `publish-catalog-with-bundles`

## Testing
- New and existing unit tests
- Tested against deployed environment to verify expected resource creation/deletion