### PR TITLE
Support Rule Promotions and resource creation/updates via raw JSON inputs.

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	gojson "encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/elasticpath/epcc-cli/external/aliases"
 	"github.com/elasticpath/epcc-cli/external/completion"
 	"github.com/elasticpath/epcc-cli/external/httpclient"
@@ -12,7 +14,6 @@ import (
 	"github.com/elasticpath/epcc-cli/external/rest"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 func NewCreateCommand(parentCmd *cobra.Command) func() {
@@ -49,6 +50,7 @@ func NewCreateCommand(parentCmd *cobra.Command) func() {
 	var logOnSuccess = ""
 	var logOnFailure = ""
 	var disableConstants = false
+	var data = ""
 
 	resetFunc := func() {
 		autoFillOnCreate = false
@@ -67,6 +69,7 @@ func NewCreateCommand(parentCmd *cobra.Command) func() {
 		logOnSuccess = ""
 		logOnFailure = ""
 		disableConstants = false
+		data = ""
 	}
 
 	for _, resource := range resources.GetPluralResources() {
@@ -106,7 +109,7 @@ func NewCreateCommand(parentCmd *cobra.Command) func() {
 						}
 					}
 
-					body, err := rest.CreateInternal(context.Background(), overrides, append([]string{resourceName}, args...), autoFillOnCreate, setAlias, skipAliases, disableConstants)
+					body, err := rest.CreateInternal(context.Background(), overrides, append([]string{resourceName}, args...), autoFillOnCreate, setAlias, skipAliases, disableConstants, data)
 
 					if err != nil {
 						return err
@@ -149,7 +152,6 @@ func NewCreateCommand(parentCmd *cobra.Command) func() {
 
 						return json.PrintJson(body)
 					}
-
 				}
 
 				res := repeater(c, repeat, repeatDelay, cmd, args, ignoreErrors)
@@ -252,6 +254,7 @@ func NewCreateCommand(parentCmd *cobra.Command) func() {
 	createCmd.PersistentFlags().BoolVarP(&disableConstants, "no-auto-constants", "", false, "Disable setting of known constant values in the request body")
 	createCmd.PersistentFlags().StringVarP(&logOnSuccess, "log-on-success", "", "", "Output the following message as an info if the result is successful")
 	createCmd.PersistentFlags().StringVarP(&logOnFailure, "log-on-failure", "", "", "Output the following message as an error if the result fails")
+	createCmd.PersistentFlags().StringVarP(&data, "data", "d", "", "Raw JSON data to use as the request body. If provided, positional arguments will be ignored.")
 
 	_ = createCmd.RegisterFlagCompletionFunc("output-jq", jqCompletionFunc)
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	gojson "encoding/json"
 	"fmt"
+	"net/url"
+	"time"
+
 	"github.com/elasticpath/epcc-cli/config"
 	"github.com/elasticpath/epcc-cli/external/aliases"
 	"github.com/elasticpath/epcc-cli/external/authentication"
@@ -17,8 +20,6 @@ import (
 	"github.com/elasticpath/epcc-cli/external/rest"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"net/url"
-	"time"
 )
 
 const (
@@ -301,7 +302,7 @@ var loginCustomer = &cobra.Command{
 		newArgs = append(newArgs, "customer-token")
 		newArgs = append(newArgs, args...)
 
-		body, err := rest.CreateInternal(ctx, overrides, newArgs, false, "", false, false)
+		body, err := rest.CreateInternal(ctx, overrides, newArgs, false, "", false, false, "")
 
 		if err != nil {
 			log.Warnf("Login not completed successfully")
@@ -511,7 +512,7 @@ var loginAccountManagement = &cobra.Command{
 		}
 
 		// Do the login and get back a list of accounts
-		body, err := rest.CreateInternal(ctx, overrides, loginArgs, false, "", false, false)
+		body, err := rest.CreateInternal(ctx, overrides, append([]string{"account-management-authentication-token"}, args...), false, "", false, false, "")
 
 		if err != nil {
 			log.Warnf("Login not completed successfully")

--- a/cmd/reset-store.go
+++ b/cmd/reset-store.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	gojson "encoding/json"
 	"fmt"
+	"io"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
 	"github.com/elasticpath/epcc-cli/external/aliases"
 	"github.com/elasticpath/epcc-cli/external/authentication"
 	"github.com/elasticpath/epcc-cli/external/httpclient"
@@ -12,11 +18,6 @@ import (
 	"github.com/elasticpath/epcc-cli/external/rest"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io"
-	"net/url"
-	"regexp"
-	"sort"
-	"strings"
 )
 
 var DeleteApplicationKeys = true
@@ -201,7 +202,7 @@ func resetResourcesUndeletableResources(ctx context.Context, overrides *httpclie
 	errors := make([]string, 0)
 
 	for _, resetCmd := range resetCmds {
-		body, err := rest.UpdateInternal(ctx, overrides, false, false, resetCmd)
+		body, err := rest.UpdateInternal(ctx, overrides, false, false, resetCmd, "")
 
 		if err != nil {
 			errors = append(errors, fmt.Errorf("error resetting  %s: %v", resetCmd[0], err).Error())

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	gojson "encoding/json"
 	"fmt"
+
 	"github.com/elasticpath/epcc-cli/external/aliases"
 	"github.com/elasticpath/epcc-cli/external/completion"
 	"github.com/elasticpath/epcc-cli/external/httpclient"
@@ -33,6 +34,7 @@ func NewUpdateCommand(parentCmd *cobra.Command) func() {
 	var logOnSuccess = ""
 	var logOnFailure = ""
 	var disableConstants = false
+	var data = ""
 
 	resetFunc := func() {
 		overrides.QueryParameters = nil
@@ -49,6 +51,7 @@ func NewUpdateCommand(parentCmd *cobra.Command) func() {
 		logOnSuccess = ""
 		logOnFailure = ""
 		disableConstants = false
+		data = ""
 	}
 
 	var updateCmd = &cobra.Command{
@@ -98,7 +101,7 @@ func NewUpdateCommand(parentCmd *cobra.Command) func() {
 						}
 					}
 
-					body, err := rest.UpdateInternal(context.Background(), overrides, skipAliases, disableConstants, append([]string{resourceName}, args...))
+					body, err := rest.UpdateInternal(context.Background(), overrides, skipAliases, disableConstants, append([]string{resourceName}, args...), data)
 
 					if err != nil {
 						return err
@@ -226,6 +229,7 @@ func NewUpdateCommand(parentCmd *cobra.Command) func() {
 	updateCmd.PersistentFlags().BoolVarP(&disableConstants, "no-auto-constants", "", false, "Disable setting of known constant values in the request body (e.g., `type`)")
 	updateCmd.PersistentFlags().StringVarP(&logOnSuccess, "log-on-success", "", "", "Output the following message as an info if the result is successful")
 	updateCmd.PersistentFlags().StringVarP(&logOnFailure, "log-on-failure", "", "", "Output the following message as an error if the result fails")
+	updateCmd.PersistentFlags().StringVarP(&data, "data", "d", "", "Raw JSON data to use as the request body. If provided, positional arguments will be ignored.")
 
 	parentCmd.AddCommand(updateCmd)
 

--- a/external/oidc/callback.go
+++ b/external/oidc/callback.go
@@ -5,10 +5,11 @@ import (
 	"encoding/base64"
 	gojson "encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/elasticpath/epcc-cli/external/authentication"
 	"github.com/elasticpath/epcc-cli/external/httpclient"
 	"github.com/elasticpath/epcc-cli/external/rest"
-	"net/http"
 )
 
 type CallbackPageInfo struct {
@@ -66,12 +67,12 @@ func GetCallbackData(ctx context.Context, port uint16, r *http.Request) (*Callba
 		}
 
 		if login_type.Value == "AM" {
-			result, err := rest.CreateInternal(context.Background(), &httpclient.HttpParameterOverrides{}, []string{"account-management-authentication-token",
+			result, err := rest.CreateInternal(ctx, &httpclient.HttpParameterOverrides{}, append([]string{"account-management-authentication-token"},
 				"authentication_mechanism", "oidc",
 				"oauth_authorization_code", data["code"],
 				"oauth_redirect_uri", fmt.Sprintf("http://localhost:%d/callback", port),
 				"oauth_code_verifier", verifier.Value,
-			}, false, "", true, false)
+			), false, "", true, false, "")
 
 			if err != nil {
 				return nil, fmt.Errorf("could not get account tokens: %w", err)
@@ -96,12 +97,12 @@ func GetCallbackData(ctx context.Context, port uint16, r *http.Request) (*Callba
 
 			return &cpi, nil
 		} else if login_type.Value == "Customers" {
-			result, err := rest.CreateInternal(context.Background(), &httpclient.HttpParameterOverrides{}, []string{"customer-token",
+			result, err := rest.CreateInternal(ctx, &httpclient.HttpParameterOverrides{}, append([]string{"customer-token"},
 				"authentication_mechanism", "oidc",
 				"oauth_authorization_code", data["code"],
 				"oauth_redirect_uri", fmt.Sprintf("http://localhost:%d/callback", port),
 				"oauth_code_verifier", verifier.Value,
-			}, false, "", true, false)
+			), false, "", true, false, "")
 
 			if err != nil {
 				return nil, fmt.Errorf("could not get customer tokens: %w", err)

--- a/external/resources/yaml/resources.yaml
+++ b/external/resources/yaml/resources.yaml
@@ -2907,5 +2907,66 @@ mli-inventory-list-stocks:
       type: CONST:stock
     data[n].id:
       type: RESOURCE_ID:pcm-products
+rule-promotions:
+  singular-name: "rule-promotion"
+  json-api-type: "rule_promotion"
+  json-api-format: "compliant"
+  docs: "https://elasticpath.dev/docs/promotions-builder/overview"
+  get-collection:
+    docs: "https://elasticpath.dev/docs/api/promotions-builder/get-rule-promotions"
+    url: "/v2/rule-promotions"
+  get-entity:
+    docs: "https://elasticpath.dev/docs/api/promotions-builder/get-rule-promotion-by-id"
+    url: "/v2/rule-promotions/{rule_promotions}"
+  create-entity:
+    docs: "https://elasticpath.dev/docs/api/promotions-builder/create-rule-promotion"
+    url: "/v2/rule-promotions"
+  update-entity:
+    docs: "https://elasticpath.dev/docs/api/promotions-builder/update-rule-promotion"
+    url: "/v2/rule-promotions/{rule_promotions}"
+  delete-entity:
+    docs: "https://elasticpath.dev/docs/api/promotions-builder/delete-rule-promotion"
+    url: "/v2/rule-promotions/{rule_promotions}"
+  attributes:
+    name:
+      type: STRING
+    description:
+      type: STRING
+    enabled:
+      type: BOOL
+    automatic:
+      type: BOOL
+    priority:
+      type: INT
+    stackable:
+      type: BOOL
+    start:
+      type: STRING
+    end:
+      type: STRING
+    rule_set.rules.strategy:
+      type: STRING
+    rule_set.rules.operator:
+      type: STRING
+    rule_set.rules.args[n]:
+      type: STRING
+    rule_set.rules.children[n].strategy:
+      type: STRING
+    rule_set.rules.children[n].operator:
+      type: STRING
+    rule_set.rules.children[n].args[n]:
+      type: STRING
+    rule_set.actions[n].strategy:
+      type: STRING
+    rule_set.actions[n].args[n]:
+      type: STRING
+    rule_set.actions[n].condition.strategy:
+      type: STRING
+    rule_set.actions[n].condition.operator:
+      type: STRING
+    rule_set.actions[n].condition.args[n]:
+      type: STRING
+    rule_set.actions[n].limitations.max_quantity:
+      type: INT
 
 


### PR DESCRIPTION
- Supports Rule Promotions
- Adds logic to support POST/PUT requests with JSON data, via the `-d`/`--data` arguments.
  - Example: `epcc create rule-promotion -d "$(cat rule_promotion.json)"`